### PR TITLE
Fix build under g++.

### DIFF
--- a/dungeon.cpp
+++ b/dungeon.cpp
@@ -194,7 +194,7 @@ class Dungeon
 
 	void NodeToXY( void* node, int* x, int* y ) 
 	{
-		int index = (int)node;
+		intptr_t index = (intptr_t)node;
 		*y = index / MAPX;
 		*x = index - *y * MAPX;
 	}

--- a/micropather.h
+++ b/micropather.h
@@ -69,6 +69,7 @@ distribution.
 	#include <stdlib.h>
 	typedef uintptr_t		MP_UPTR;
 #elif defined (__GNUC__) && (__GNUC__ >= 3 )
+	#include <stdint.h>
 	#include <stdlib.h>
 	typedef uintptr_t		MP_UPTR;
 #else


### PR DESCRIPTION
g++ requires stdint.h (or cstdint in C++11) for [u]intptr_t to be available, and won't compile a cast from a pointer to a differently-sized type.
