### PR TITLE
Add a virtual comperator function to the MicroPather class

### DIFF
--- a/micropather.cpp
+++ b/micropather.cpp
@@ -836,6 +836,8 @@ void MicroPather::GetCacheData( CacheData* data )
 	}
 }
 
+
+
 int MicroPather::Solve( void* startNode, void* endNode, MP_VECTOR< void* >* path, float* cost )
 {
 	// Important to clear() in case the caller doesn't check the return code. There

--- a/micropather.h
+++ b/micropather.h
@@ -184,7 +184,6 @@ namespace micropather
 			without an ending newline.
 		*/
 		virtual void  PrintStateInfo( void* state ) = 0;
-
 	};
 
 


### PR DESCRIPTION
I've introduced a virtual comperator method to the MicroPather class. This way comparison of two nodes can be done in the _Graph_ subclass. There might be other places where replacing node A == node B with graph->NodesEqual(A, B) might be necessary. 
