### PR TITLE
Allow external users of micropather.h to define MPASSERT

### DIFF
--- a/micropather.h
+++ b/micropather.h
@@ -53,13 +53,9 @@ distribution.
 #endif
 
 
-#if defined( _DEBUG )
-#	if defined( _MSC_VER )
-#		define MPASSERT( x )		if ( !(x)) { _asm { int 3 } }
-#	else
-#		include <assert.h>
-#		define MPASSERT assert
-#	endif
+#if defined( _DEBUG ) && !defined( MPASSERT )
+#	include <assert.h>
+#	define MPASSERT assert
 #else
 #	define MPASSERT( x ) {}
 #endif


### PR DESCRIPTION
We shouldn't be calling a raw assembly "int 3" -- leave that up to the consumers of the library to do if they want.