### PR TITLE
Fix signed/unsigned comparison warnings

### DIFF
--- a/micropather.h
+++ b/micropather.h
@@ -391,8 +391,8 @@ namespace micropather
 		const Item* Find( void* start, void* end );
 		
 		Item*	mem;
-		int		allocated;
-		int		nItems;
+		unsigned	allocated;
+		unsigned	nItems;
 	};
 
 	struct CacheData {


### PR DESCRIPTION
Tagging #11

Fixes the following GCC warnings:
```
micropather.cpp: In member function ‘void micropather::PathCache::AddItem(const micropather::PathCache::Item&)’:
micropather.cpp:808:14: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
   if ( index == allocated )
        ~~~~~~^~~~~~~~~~~~
micropather.cpp: In member function ‘const micropather::PathCache::Item* micropather::PathCache::Find(void*, void*)’:
micropather.cpp:827:14: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
   if ( index == allocated )
        ~~~~~~^~~~~~~~~~~~
```
