### PR TITLE
Fix warning for `memset` of non-trivial type

### DIFF
--- a/micropather.cpp
+++ b/micropather.cpp
@@ -832,7 +832,7 @@ const PathCache::Item* PathCache::Find( void* start, void* end )
 
 void MicroPather::GetCacheData( CacheData* data )
 {
-	memset( data, 0, sizeof(*data) );
+	*data = {};
 
 	if ( pathCache ) {
 		data->nBytesAllocated = pathCache->AllocatedBytes();


### PR DESCRIPTION
Tagging #11

Fixes GCC warning:
```
micropather.cpp: In member function ‘void micropather::MicroPather::GetCacheData(micropather::CacheData*)’:
micropather.cpp:835:33: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct micropather::CacheData’; use assignment or value-initialization instead [-Wclass-memaccess]
  memset( data, 0, sizeof(*data) );
                                 ^
In file included from micropather.cpp:43:
micropather.h:398:9: note: ‘struct micropather::CacheData’ declared here
  struct CacheData {
         ^~~~~~~~~
```
